### PR TITLE
fixed pep8 violations and removed unused import

### DIFF
--- a/metrics/coverage.py
+++ b/metrics/coverage.py
@@ -34,6 +34,7 @@ USAGE = u"USAGE: {prog} GROUPS_JSON COVER_XML_1 [COVER_XML_2, ...] "
 
 
 class CoverageParseError(Exception):
+
     """
     Error occurred while parsing a coverage report.
     """
@@ -41,6 +42,7 @@ class CoverageParseError(Exception):
 
 
 class CoverageData(object):
+
     """
     Aggregate coverage reports.
     """
@@ -103,7 +105,6 @@ class CoverageData(object):
                             elif line_num not in self._coverage[class_filename]:
                                 self._coverage[class_filename][line_num] = 0
 
-
     def coverage(self, source_pattern="*"):
         """
         Calculate line coverage percentage (float) for source files that match
@@ -127,7 +128,6 @@ class CoverageData(object):
         else:
             print u"Warning: No lines found in source files that match {}".format(source_pattern)
             return None
-
 
     def _parse_report(self, report_path):
         """

--- a/metrics/tests/test_coverage.py
+++ b/metrics/tests/test_coverage.py
@@ -1,7 +1,7 @@
 import os
 import StringIO
 from unittest import TestCase
-from mock import patch, MagicMock
+from mock import patch
 from ddt import ddt, unpack, data
 from ..coverage import CoverageData, CoverageParseError, configure_datadog
 
@@ -66,10 +66,9 @@ class MainTest(TestCase):
         If no DATADOG_API_KEY is set, the script should exit with a helpful message.
         """
         helpful_message = u"Must specify DataDog API key with env var DATADOG_API_KEY\n"
-        _env_vars= dict(os.environ)
+        _env_vars = dict(os.environ)
         os.environ.clear()
         with self.assertRaises(SystemExit):
             configure_datadog()
         self.assertEqual(mock_stdout.getvalue(), helpful_message)
         os.environ.update(_env_vars)
-


### PR DESCRIPTION
if you are interested, this branch fixes all pep8 violations, and removes an unused import.

btw, "autopep8" is your friend:
  `$ autopep8 . --in-place --recursive --aggressive --max-line-length=120`

happy hacking,
-Corey